### PR TITLE
fix: tutorial typo

### DIFF
--- a/docs/src/pages/docs/typography/getting-started.astro
+++ b/docs/src/pages/docs/typography/getting-started.astro
@@ -19,7 +19,7 @@ import DocsLayout from '~/layouts/DocsLayout.astro';
     <StepListItem heading="Installation">
       <div class="prose prose-mauve">
         <p>
-          Install <code>windy-radix-typogrpahy</code> and its peer dependencies using
+          Install <code>windy-radix-typography</code> and its peer dependencies using
           your package manager of choice.
         </p>
         <p>


### PR DESCRIPTION
No big deal, but I pasted this typo in my shell by mistake and it could have installed a fake package or something