### PR TITLE
feat: allow rootKey to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,15 @@ module.exports = {
 };
 ```
 
-### Root Key
+### Root Selector
 
-By default, this plugin will add CSS Variable to the `:root` identifier (which points to the root of the current DOM frame). To switch the rootKey to `:host` for example when working with shadowDOM, pass a rootKey option to the plugin:
-
-
-default, this plugin will add CSS properties for **all** of the available Radix Colors. If you would rather only include the properties for colors that you are actually using, you can pass these as an option to the plugin:
+By default, this plugin will add CSS properties to the `:root` CSS [pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:root). The selector where these properties are placed can be customized via the `rootSelector` option. For example, when working with shadow DOM you might want to put the properties under the `:host` selector:
 
 ```js
-
 module.exports = {
 	plugins: [
 		require("windy-radix-palette")({
-				rootKey: ":host",
+				rootSelector: ":host",
 			},
 		}),
 	],

--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ module.exports = {
 };
 ```
 
+### Root Key
+
+By default, this plugin will add CSS Variable to the `:root` identifier (which points to the root of the current DOM frame). To switch the rootKey to `:host` for example when working with shadowDOM, pass a rootKey option to the plugin:
+
+
+default, this plugin will add CSS properties for **all** of the available Radix Colors. If you would rather only include the properties for colors that you are actually using, you can pass these as an option to the plugin:
+
+```js
+
+module.exports = {
+	plugins: [
+		require("windy-radix-palette")({
+				rootKey: ":host",
+			},
+		}),
+	],
+};
+```
+
 ## Dark mode
 
 Thanks to the design of the Radix Colors palettes, you don't actually need to do anything to make dark mode work! The colors in this palette will automatically switch to the light/dark variant based on your Tailwind dark mode settings:

--- a/docs/src/pages/docs/palette/options.astro
+++ b/docs/src/pages/docs/palette/options.astro
@@ -6,7 +6,7 @@ import DocsLayout from "~/layouts/DocsLayout.astro";
 	title="Options"
 	description="Plugin options for windy-radix-palette"
 >
-	<div class="prose prose-mauve prose-headings:font-medium">
+	<div class="prose prose-mauve prose-headings:font-medium pb-8">
 		<h2>Colors</h2>
 		<p>
 			By default, CSS properties will be created for <strong>all</strong> colors
@@ -25,6 +25,26 @@ module.exports = {
         red: radixColors.red,
         redDark: radixColors.redDark,
       },
+    }),
+  ],
+};`}</code></pre>
+	</div>
+	<div class="prose prose-mauve prose-headings:font-medium pb-8">
+		<h2>Root Selector</h2>
+		<p>
+			By default, this plugin will add CSS properties to the <code>:root</code> CSS
+			<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:root"
+				>pseudo-class</a
+			>. The selector where these properties are placed can be customized via
+			the <code>rootSelector</code> option. For example, when working with shadow
+			DOM you might want to put the properties under the <code>:host</code> selector.
+		</p>
+		<pre><code>{`const radixColors = require('@radix-ui/colors');
+
+module.exports = {
+  plugins: [
+    require('windy-radix-palette')({
+      rootSelector: ':host'
     }),
   ],
 };`}</code></pre>

--- a/packages/palette/index.js
+++ b/packages/palette/index.js
@@ -2,7 +2,7 @@ const radix = require("@radix-ui/colors");
 const plugin = require("tailwindcss/plugin");
 
 const windyRadixPalette = plugin.withOptions(
-	({ colors = radix, rootKey = ":root" } = {}) => {
+	({ colors = radix, rootSelector = ":root" } = {}) => {
 		let rootColors = {};
 		let darkModeColors = {};
 
@@ -20,14 +20,14 @@ const windyRadixPalette = plugin.withOptions(
 
 			if (darkMode === "class") {
 				addBase({
-					[rootKey]: rootColors,
+					[rootSelector]: rootColors,
 					[className]: darkModeColors,
 				});
 			} else {
 				addBase({
-					[rootKey]: rootColors,
+					[rootSelector]: rootColors,
 					"@media (prefers-color-scheme: dark)": {
-						":root": darkModeColors,
+						[rootSelector]: darkModeColors,
 					},
 				});
 			}

--- a/packages/palette/index.js
+++ b/packages/palette/index.js
@@ -2,7 +2,7 @@ const radix = require("@radix-ui/colors");
 const plugin = require("tailwindcss/plugin");
 
 const windyRadixPalette = plugin.withOptions(
-	({ colors = radix } = {}) => {
+	({ colors = radix, rootKey = ":root" } = {}) => {
 		let rootColors = {};
 		let darkModeColors = {};
 
@@ -20,12 +20,12 @@ const windyRadixPalette = plugin.withOptions(
 
 			if (darkMode === "class") {
 				addBase({
-					":root": rootColors,
+					[rootKey]: rootColors,
 					[className]: darkModeColors,
 				});
 			} else {
 				addBase({
-					":root": rootColors,
+					[rootKey]: rootColors,
 					"@media (prefers-color-scheme: dark)": {
 						":root": darkModeColors,
 					},


### PR DESCRIPTION
This allows the CSS Variable injected by the plugin to be used inside non-root frame, such as shadowHost, i.e, by setting the rootKey to `host:`