### PR TITLE
add typings to plugins

### DIFF
--- a/packages/palette/index.d.ts
+++ b/packages/palette/index.d.ts
@@ -1,0 +1,7 @@
+declare function plugin(options?: Partial<{ colors: object, rootSelector: string }>): { handler: () => void }
+
+declare namespace plugin {
+  const __isOptionsFunction: true
+}
+
+export = plugin

--- a/packages/palette/index.d.ts
+++ b/packages/palette/index.d.ts
@@ -1,7 +1,28 @@
-declare function plugin(options?: Partial<{ colors: object, rootSelector: string }>): { handler: () => void }
+import type * as radixColors from "@radix-ui/colors";
 
-declare namespace plugin {
-  const __isOptionsFunction: true
+declare type DeepPartial<T> = T extends object
+	? { [P in keyof T]?: DeepPartial<T[P]> }
+	: T;
+
+declare interface WindyRadixPaletteOptions {
+	/**
+	 * The Radix colors to generate a palette for.
+	 * @default All Radix colors.
+	 */
+	colors?: DeepPartial<typeof radixColors>;
+	/**
+	 * The selector that the color variables will be added to.
+	 * @default ':root'
+	 */
+	rootSelector?: string;
 }
 
-export = plugin
+declare function plugin(options?: Partial<WindyRadixPaletteOptions>): {
+	handler: () => void;
+};
+
+declare namespace plugin {
+	const __isOptionsFunction: true;
+}
+
+export = plugin;

--- a/packages/palette/package.json
+++ b/packages/palette/package.json
@@ -3,6 +3,7 @@
 	"version": "0.6.0",
 	"description": "Bring Radix Colors to Tailwind CSS",
 	"main": "index.js",
+	"types": "index.d.ts",
 	"repository": {
 		"url": "https://github.com/brattonross/windy-radix-palette",
 		"directory": "packages/palette"
@@ -17,7 +18,9 @@
 	],
 	"files": [
 		"index.js",
-		"vars.js"
+		"index.d.ts",
+		"vars.js",
+		"vars.d.ts"
 	],
 	"author": "Ross Bratton <bratton.ross@gmail.com>",
 	"license": "MIT",

--- a/packages/palette/vars.d.ts
+++ b/packages/palette/vars.d.ts
@@ -1,0 +1,11 @@
+import type * as radixColors from "@radix-ui/colors";
+
+declare type RadixColor = keyof typeof radixColors;
+declare type RadixScale = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+declare function toRadixVar(
+	color: RadixColor,
+	n: RadixScale | `${RadixScale}`
+): string;
+
+declare function toRadixVars(color: RadixColor): Record<string, string>;

--- a/packages/typography/index.d.ts
+++ b/packages/typography/index.d.ts
@@ -1,7 +1,19 @@
-declare function plugin(options?: Partial<{ colors: string[] }>): { handler: () => void }
+import type * as radixColors from "@radix-ui/colors";
 
-declare namespace plugin {
-  const __isOptionsFunction: true
+declare interface WindyRadixTypographyOptions {
+  /**
+   * The names of the colors to have a typography variant generated for.
+   * @default ["gray", "mauve", "slate", "sage", "olive", "sand"]
+   */
+  colors?: Array<keyof typeof radixColors>;
 }
 
-export = plugin
+declare function plugin(options?: Partial<WindyRadixTypographyOptions>): {
+  handler: () => void;
+};
+
+declare namespace plugin {
+  const __isOptionsFunction: true;
+}
+
+export = plugin;

--- a/packages/typography/index.d.ts
+++ b/packages/typography/index.d.ts
@@ -1,0 +1,7 @@
+declare function plugin(options?: Partial<{ colors: string[] }>): { handler: () => void }
+
+declare namespace plugin {
+  const __isOptionsFunction: true
+}
+
+export = plugin

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -3,6 +3,7 @@
 	"version": "0.2.0",
 	"description": "Bring Radix Colors to Tailwind Typography",
 	"main": "index.js",
+	"types": "index.d.ts",
 	"repository": {
 		"url": "https://github.com/brattonross/windy-radix-palette",
 		"directory": "packages/typography"
@@ -16,7 +17,8 @@
 		"radix-ui"
 	],
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"author": "Ross Bratton <bratton.ross@gmail.com>",
 	"license": "MIT",


### PR DESCRIPTION
I modeled the types after official tailwind plugins. This eliminates errors in a type-checked tailwind configuration.
Closes #17 