### PR TITLE
fix: respect dark mode config

### DIFF
--- a/packages/palette/src/plugin.ts
+++ b/packages/palette/src/plugin.ts
@@ -36,7 +36,7 @@ export function createPlugin({
 }: PluginOptions = {}) {
 	const wrpPlugin = plugin(({ addBase, addVariant, config }) => {
 		const baseStyles = generateBaseStyles({ colors, opacitySupport });
-		const [darkMode, className = ".dark"] = [config("darkMode", "media")];
+		const [darkMode, className = ".dark"] = config("darkMode", "media");
 
 		addVariant(
 			"p3",


### PR DESCRIPTION
Fixes an issue where the Tailwind dark mode config would not be respected when set as an array (fixes #24)