### PR TITLE
fix: use color step when aliasing scale

### DIFF
--- a/packages/palette/src/alias.ts
+++ b/packages/palette/src/alias.ts
@@ -145,7 +145,7 @@ export class Aliaser {
 			} else {
 				for (let i = 1; i <= steps.length; i++) {
 					lightTable[`--${variableName}-${i}`] = themeFn(
-						`colors.${light}`,
+						`colors.${light}.${i}`,
 						`var(--${light}${i})`,
 					);
 				}
@@ -162,7 +162,7 @@ export class Aliaser {
 			} else {
 				for (let i = 1; i <= steps.length; i++) {
 					darkTable[`--${variableName}-${i}`] = themeFn(
-						`colors.${dark}`,
+						`colors.${dark}.${i}`,
 						`var(--${dark}${i})`,
 					);
 				}


### PR DESCRIPTION
Fixes an issue where the theme function was getting called incorrectly when aliasing entire color scales.

Fixes #27 