### PR TITLE
Fix typography docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ const colors = createPlugin();
 
 module.exports = {
 	plugins: [colors.plugin, require("@tailwindcss/typography")],
-	presets: [require("windy-radix-typography")],
+	presets: [require("windy-radix-typography").preset],
 };
 ```
 


### PR DESCRIPTION
I ran into issues make the typography plugin (1.0.0-beta.0) work according to the docs. I did a little digging and found that adding `.preset` after `require("windy-radix-typography")` does the trick.